### PR TITLE
FIX: use mysqli_real_escape_string if TYPO3 Version >= 6.1

### DIFF
--- a/Classes/Domain/DataBackend/MySqlDataBackend/MySqlInterpreter/SimpleCriteriaTranslator.php
+++ b/Classes/Domain/DataBackend/MySqlDataBackend/MySqlInterpreter/SimpleCriteriaTranslator.php
@@ -63,7 +63,17 @@ class Tx_PtExtlist_Domain_DataBackend_MySqlDataBackend_MySqlInterpreter_SimpleCr
         } elseif(is_numeric($value)) {
 			$returnString = $value;
 		} else {
-			$returnString = self::wrapNonNumericValue(mysql_real_escape_string($value));
+			if (class_exists('t3lib_utility_VersionNumber')) {
+				$t3Version = t3lib_utility_VersionNumber::convertVersionNumberToInteger(TYPO3_version);
+			} else {
+				$t3Version = t3lib_div::int_from_ver(TYPO3_version);
+			}
+
+			if ($t3Version < 6001000) {
+				$returnString = self::wrapNonNumericValue(mysql_real_escape_string($value));
+			} else {
+				$returnString = self::wrapNonNumericValue(mysqli_real_escape_string($GLOBALS['TYPO3_DB']->getDatabaseHandle(), $value));
+			}
 		}
 		return $returnString;
 	}


### PR DESCRIPTION
Since TYPO3 6.1 we use mysqli for Database stuff so mysql_real_escape_string won't work.
We have to use mysqli_real_escape_string.
