### PR TITLE
FIX: remove a warning if ExcelListView is called and cells contain an empty array

### DIFF
--- a/Classes/View/Export/ExcelListView.php
+++ b/Classes/View/Export/ExcelListView.php
@@ -347,6 +347,16 @@ class Tx_PtExtlist_View_Export_ExcelListView extends Tx_PtExtlist_View_Export_Ab
                 /* @var $listCell Tx_PtExtlist_Domain_Model_List_Cell */
 
                 $cellValue = $listCell->getValue();
+
+                if (is_array($cellValue)) {
+                    if (empty($cellValue)) {
+                        $cellValue = '';
+                    } else {
+                        throw new \TYPO3\CMS\Core\Error\Http\StatusException([\TYPO3\CMS\Core\Utility\HttpUtility::HTTP_STATUS_500],
+                            'Array given to render in excel, string expected', '', 1518776229);
+                    }
+                }
+
                 if ($this->stripTags) {
                     $cellValue = strip_tags($cellValue);
                 }


### PR DESCRIPTION
this can happen if you do some render object magic in the exlist config. For empty
arrays we just use an empty string as the field value. If somehow an array with
content is to be sent to excel, we throw a proper exception